### PR TITLE
Add version to remoting.jar

### DIFF
--- a/jenkins-slave.rb
+++ b/jenkins-slave.rb
@@ -26,7 +26,7 @@ class JenkinsSlave < Formula
         <array>
           <string>/usr/bin/java</string>
           <string>-jar</string>
-          <string>#{libexec}/remoting.jar</string>
+          <string>#{libexec}/remoting-#{version}.jar</string>
           <string>-jnlpUrl</string>
           <string>REPLACE_ME_JENKINS_URL</string>
           <string>-secret</string>


### PR DESCRIPTION
Starting the jenkins-slave does not work beause the version is missing from the remoting.jar in the plist file. This PR fixes this.